### PR TITLE
Fixed error with lead time calculation

### DIFF
--- a/tests/hlm_seed_model_test.R
+++ b/tests/hlm_seed_model_test.R
@@ -326,7 +326,7 @@ final[, `:=`(c("geographicAreaM49Name", "cpclv1", "cpclv2", "cpclv3",
 
 setkeyv(final, cols = c("geographicAreaM49", "measuredItemCPC", "timePointYears"))
 ## Create lagged area sown
-final[, leadAreaSown := c(.SD[0:(.N - 1), areaSown], NA),
+final[, leadAreaSown := c(NA, .SD[0:(.N - 1), areaSown]),
       by = c("geographicAreaM49", "measuredItemCPC")]
 
 seedRemoveCarryForward = removeCarryForward(final, "seed")

--- a/tests/hlm_seed_model_test.R
+++ b/tests/hlm_seed_model_test.R
@@ -326,8 +326,9 @@ final[, `:=`(c("geographicAreaM49Name", "cpclv1", "cpclv2", "cpclv3",
 
 setkeyv(final, cols = c("geographicAreaM49", "measuredItemCPC", "timePointYears"))
 ## Create lagged area sown
-final[, leadAreaSown := c(NA, .SD[0:(.N - 1), areaSown]),
-      by = c("geographicAreaM49", "measuredItemCPC")]
+final[, leadAreaSown := c(.SD[2:.N, areaSown], NA),
+       by = c("geographicAreaM49", "measuredItemCPC")]
+
 
 seedRemoveCarryForward = removeCarryForward(final, "seed")
 seedFinalData = subset(seedRemoveCarryForward,


### PR DESCRIPTION
I wasn't sure exactly how leadAreaSown was meant to be defined, but I think the current calculation is wrong.  My guess is that it should either be as I have edited it or line 329 should be:

final[, leadAreaSown := c(.SD[1:.N, areaSown], NA)

The R^2 drops to about 95% in this case (at least, for random sample I selected), but it still seems like a pretty good fit.
